### PR TITLE
Fix issue when fmt is no longer provided by Ember

### DIFF
--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -15,7 +15,7 @@ module.exports = function(environment) {
       EXTEND_PROTOTYPES: {
         // Prevent Ember Data from overriding Date.parse.
         Date: false,
-        String: false,
+        String: true,
         Array: false
       }
     },

--- a/tests/unit/string-fmt-test.js
+++ b/tests/unit/string-fmt-test.js
@@ -13,6 +13,11 @@ test('that Ember.String.fmt formats a string', function(assert) {
   assert.equal(Ember.String.fmt('Hello %@ %@', ['John', 'Madden']), 'Hello John Madden')
 });
 
+test('that when EXTEND_PROTOTYPES Sting is true the prototype is polyfilled', function(assert) {
+  assert.equal("Hello %@ %@".fmt('John', 'Doe'), "Hello John Doe");
+  assert.equal("Hello %@2, %@1".fmt('John', 'Doe'), "Hello Doe, John");
+});
+
 test('that Ember.String.fmt is deprecated', function(assert) {
   assert.expectDeprecation(() => {
     let result = Ember.String.fmt('%@', 'Hello');

--- a/vendor/string-fmt.js
+++ b/vendor/string-fmt.js
@@ -17,7 +17,7 @@
   function _fmt(str, formats) {
     let cachedFormats = formats;
 
-    if (!Ember.isArray(cachedFormats) || arguments.length > 2) {
+    if (!_Ember.isArray(cachedFormats) || arguments.length > 2) {
       cachedFormats = new Array(arguments.length - 1);
 
       for (let i = 1; i < arguments.length; i++) {
@@ -30,7 +30,7 @@
     return str.replace(/%@([0-9]+)?/g, (s, argIndex) => {
       argIndex = (argIndex) ? parseInt(argIndex, 10) - 1 : idx++;
       s = cachedFormats[argIndex];
-      return (s === null) ? '(null)' : (s === undefined) ? '' : inspect(s);
+      return (s === null) ? '(null)' : (s === undefined) ? '' : _Ember.inspect(s);
     });
   }
 
@@ -81,6 +81,6 @@
   }
 
   Object.defineProperty(_Ember.String, 'fmt', {
-    get: fmt
+    value: fmt
   });
 })();


### PR DESCRIPTION
This fixes an issue that is now happening in beta/canary builds as
they do not have Ember.String.fmt