### PR TITLE
Allow vendor tree to be transpiled.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -5,7 +5,10 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
-    // Add options here
+    // required to work around https://github.com/ember-cli/ember-cli/issues/7505
+    trees: {
+      vendor: null,
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -20,5 +20,17 @@ module.exports = {
     this.import('vendor/string-fmt.js');
     this.import('vendor/freezable.js');
     this.import('vendor/component-defaultlayout.js');
-  }
+  },
+
+  treeForVendor(rawVendorTree) {
+    let babelAddon = this.addons.find(addon => addon.name === 'ember-cli-babel');
+
+    let transpiledVendorTree = babelAddon.transpileTree(rawVendorTree, {
+      'ember-cli-babel': {
+        compileModules: false,
+      },
+    });
+
+    return transpiledVendorTree;
+  },
 };


### PR DESCRIPTION
Lets use lovely yummy ES6 (except modules) in `vendor/`.