### PR TITLE
Use Ember ^3.0.0-beta.2 as default version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-qunit-assert-helpers": "^0.2.1",
-    "ember-source": "~2.18.0",
+    "ember-source": "~3.0.0-beta.2",
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2119,9 +2119,9 @@ ember-router-generator@^1.0.0, ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-source@~2.18.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-2.18.0.tgz#f61cf2701d8aa94a6adee6d47b1d5a73a4cef5f6"
+ember-source@~3.0.0-beta.2:
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.0.0-beta.2.tgz#011c43464d3a1519b120eec15f58eb4b2331702b"
   dependencies:
     broccoli-funnel "^2.0.1"
     broccoli-merge-trees "^2.0.0"


### PR DESCRIPTION
This makes simple testing a bit easier (by allowing us to test the polyfills via `ember s` directly).