### PR TITLE
Fixes #60: Add build time flags for deprecation toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 # Ember 2 Legacy
 
-During the 2.x series in Ember.JS [serveral deprecations were added](https://www.emberjs.com/deprecations/v2.x/) with a target removal version of 3.0. This addon adds back those deprecations and the
-deprecated code that was removed. The goal of this addon is to allow Ember users who have deprecations that are preventing them from upgrading to 3.0 a path forward. **After Ember 3.4 is released this
-addon will no longer be compatible with Ember**. It should be used to provide extra time for migrating away from deprecations, not as a permanent solution.
+During the 2.x series in Ember.JS [serveral deprecations were added](https://www.emberjs.com/deprecations/v2.x/) with a target removal version of 3.0. This addon adds back those deprecations and the deprecated code that was removed. The goal of this addon is to allow Ember users who have deprecations that are preventing them from upgrading to 3.0 a path forward. **After Ember 3.4 is released this addon will no longer be compatible with Ember**. It should be used to provide extra time for migrating away from deprecations, not as a permanent solution.
 
-For more background about what and why APIs are being remove for Ember.JS 3.0 please check out the [Road to Ember 3.0](https://emberjs.com/blog/2017/10/03/the-road-to-ember-3-0.html#toc_api-removals-in-3-0) blog
-post which goes into more details.
+For more background about what and why APIs are being remove for Ember.JS 3.0 please check out the [Road to Ember 3.0](https://emberjs.com/blog/2017/10/03/the-road-to-ember-3-0.html#toc_api-removals-in-3-0) blog post which goes into more details.
 
 ## Installation
 
@@ -16,3 +13,35 @@ ember install ember-2-legacy
 ## What Deprecations are Covered
 
 All [deprecations found here](https://www.emberjs.com/deprecations/v2.x/) which have a `until: 3.0.0` are currently supported by this addon.
+
+In `ember-cli-build.js` you can specify a config for `ember-2-legacy`. This object has individual flags as key names and they can be turned off simply by setting a flag to `false`. Below is a sample config which shows all of the flag names (note all all `true` by default):
+
+```js
+new EmberApp(defaults, {
+  'ember-2-legacy': {
+    'ember-k': false,
+    'safe-string': false,
+    'enumerable-contains': false,
+    'underscore-actions': false,
+    'reversed-observer-args': false,
+    'initializer-arity': false,
+    'router-resouce': false,
+    'current-when': false,
+    'controller-wrapped': false,
+    'application-registry': false,
+    'immediate-observer': false,
+    'string-fmt': false,
+    'ember-freezable': false,
+    'component-defaultLayout': false,
+    'ember-binding': false,
+    'input-transform': false,
+    'deprecation-options': false,
+    'orphaned-outlets': false,
+    'warn-options': false,
+    'resolver-function': false,
+    'init-attrs': false,
+    'render-support': false,
+    'property-required': false
+  }
+});
+```

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,5 +2,31 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return {};
+  return {
+    EmberENV: {
+      _ENABLE_EMBER_K_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_code-ember-k-code
+      _ENABLE_DEPRECATION_OPTIONS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_id-ember-debug-deprecate-test-as-function
+      _ENABLE_ORPHANED_OUTLETS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet
+      _ENABLE_WARN_OPTIONS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_id-ember-debug-deprecate-test-as-function
+      _ENABLE_SAFE_STRING_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring
+      _ENABLE_ENUMERABLE_CONTAINS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains
+      _ENABLE_UNDERSCORE_ACTIONS_SUPPORT: true, // N/A
+      _ENABLE_RESOLVER_FUNCTION_SUPPORT: true, // https://emberjs.com/deprecations/v2.x/#toc_registry-resolver-as-function
+      _ENABLE_DID_INIT_ATTRS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs
+      _ENABLE_RENDER_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet
+      _ENABLE_REVERSED_OBSERVER_SUPPORT: true, // https://www.emberjs.com/deprecations/v1.x/#toc_reversed-ember-observer-arguments
+      _ENABLE_INITIALIZER_ARGUMENTS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_initializer-arity
+      _ENABLE_ROUTER_RESOURCE: true, // N/A
+      _ENABLE_CURRENT_WHEN_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_link-to-s-code-currentwhen-code
+      _ENABLE_DEPRECATED_REGISTRY_SUPPORT: true, // https://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry
+      _ENABLE_IMMEDIATE_OBSERVER_SUPPORT: true, // https://www.emberjs.com/deprecations/v1.x/#toc_ember-immediateobserver
+      _ENABLE_STRING_FMT_SUPPORT: true, // https://emberjs.com/deprecations/v2.x/#toc_ember-string-fmt
+      _ENABLE_FREEZABLE_SUPPORT: true, // https://emberjs.com/deprecations/v1.x/#toc_ember-freezable
+      _ENABLE_COMPONENT_DEFAULTLAYOUT_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-defaultlayout
+      _ENABLE_CONTROLLER_WRAPPED_SUPPORT: true, // https://www.emberjs.com/deprecations/v1.x/#toc_objectcontroller
+      _ENABLE_PROPERTY_REQUIRED_SUPPORT: true, // N/A
+      _ENABLE_BINDING_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_ember-binding
+      _ENABLE_INPUT_TRANSFORM_SUPPORT: true // N/A
+    }
+  };
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -2,31 +2,5 @@
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {
-  return {
-    EmberENV: {
-      _ENABLE_EMBER_K_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_code-ember-k-code
-      _ENABLE_DEPRECATION_OPTIONS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_id-ember-debug-deprecate-test-as-function
-      _ENABLE_ORPHANED_OUTLETS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet
-      _ENABLE_WARN_OPTIONS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_id-ember-debug-deprecate-test-as-function
-      _ENABLE_SAFE_STRING_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring
-      _ENABLE_ENUMERABLE_CONTAINS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains
-      _ENABLE_UNDERSCORE_ACTIONS_SUPPORT: true, // N/A
-      _ENABLE_RESOLVER_FUNCTION_SUPPORT: true, // https://emberjs.com/deprecations/v2.x/#toc_registry-resolver-as-function
-      _ENABLE_DID_INIT_ATTRS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs
-      _ENABLE_RENDER_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_rendering-into-a-render-helper-that-resolves-to-an-outlet
-      _ENABLE_REVERSED_OBSERVER_SUPPORT: true, // https://www.emberjs.com/deprecations/v1.x/#toc_reversed-ember-observer-arguments
-      _ENABLE_INITIALIZER_ARGUMENTS_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_initializer-arity
-      _ENABLE_ROUTER_RESOURCE: true, // N/A
-      _ENABLE_CURRENT_WHEN_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_link-to-s-code-currentwhen-code
-      _ENABLE_DEPRECATED_REGISTRY_SUPPORT: true, // https://emberjs.com/deprecations/v2.x/#toc_ember-application-registry-ember-applicationinstance-registry
-      _ENABLE_IMMEDIATE_OBSERVER_SUPPORT: true, // https://www.emberjs.com/deprecations/v1.x/#toc_ember-immediateobserver
-      _ENABLE_STRING_FMT_SUPPORT: true, // https://emberjs.com/deprecations/v2.x/#toc_ember-string-fmt
-      _ENABLE_FREEZABLE_SUPPORT: true, // https://emberjs.com/deprecations/v1.x/#toc_ember-freezable
-      _ENABLE_COMPONENT_DEFAULTLAYOUT_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-defaultlayout
-      _ENABLE_CONTROLLER_WRAPPED_SUPPORT: true, // https://www.emberjs.com/deprecations/v1.x/#toc_objectcontroller
-      _ENABLE_PROPERTY_REQUIRED_SUPPORT: true, // N/A
-      _ENABLE_BINDING_SUPPORT: true, // https://www.emberjs.com/deprecations/v2.x/#toc_ember-binding
-      _ENABLE_INPUT_TRANSFORM_SUPPORT: true // N/A
-    }
-  };
+  return {};
 };

--- a/index.js
+++ b/index.js
@@ -1,12 +1,38 @@
 /* eslint-env node */
 'use strict'
 
+const debug = require('debug')('ember-2-legacy');
+const version = require('./package.json').version;
 const mergeTrees = require('broccoli-merge-trees');
 const writeFile = require('broccoli-file-creator');
-const version = require('./package.json').version;
 const VersionChecker = require('ember-cli-version-checker');
 
 const minEmberVersion = '3.0.0-beta.3';
+const flagToEnvironment = {
+  'ember-k': '_ENABLE_EMBER_K_SUPPORT',
+  'safe-string': '_ENABLE_SAFE_STRING_SUPPORT',
+  'enumerable-contains': '_ENABLE_ENUMERABLE_CONTAINS_SUPPORT',
+  'underscore-actions': '_ENABLE_UNDERSCORE_ACTIONS_SUPPORT',
+  'reversed-observer': '_ENABLE_REVERSED_OBSERVER_SUPPORT',
+  'initializer-arity': '_ENABLE_INITIALIZER_ARGUMENTS_SUPPORT',
+  'router-resource': '_ENABLE_ROUTER_RESOURCE',
+  'current-when': '_ENABLE_CURRENT_WHEN_SUPPORT',
+  'controller-wrapped': '_ENABLE_CONTROLLER_WRAPPED_SUPPORT',
+  'application-registry': '_ENABLE_DEPRECATED_REGISTRY_SUPPORT',
+  'immediate-observer': '_ENABLE_IMMEDIATE_OBSERVER_SUPPORT',
+  'string-fmt': '_ENABLE_STRING_FMT_SUPPORT',
+  'ember-freezable': '_ENABLE_FREEZABLE_SUPPORT',
+  'component-defaultlayout': '_ENABLE_COMPONENT_DEFAULTLAYOUT_SUPPORT',
+  'ember-binding': '_ENABLE_BINDING_SUPPORT',
+  'input-transform': '_ENABLE_INPUT_TRANSFORM_SUPPORT',
+  'deprecation-options': '_ENABLE_DEPRECATION_OPTIONS_SUPPORT',
+  'orphaned-outlets': '_ENABLE_ORPHANED_OUTLETS_SUPPORT',
+  'warn-options': '_ENABLE_WARN_OPTIONS_SUPPORT',
+  'resolver-function': '_ENABLE_RESOLVER_FUNCTION_SUPPORT',
+  'init-attrs': '_ENABLE_DID_INIT_ATTRS_SUPPORT',
+  'render-support': '_ENABLE_RENDER_SUPPORT',
+  'property-required': '_ENABLE_PROPERTY_REQUIRED_SUPPORT'
+};
 
 module.exports = {
   name: 'ember-2-legacy',
@@ -18,49 +44,53 @@ module.exports = {
     this.emberVersion = checker.forEmber();
   },
 
-  config() {
-    // do nothing if running with Ember 2.x
-    if (this.emberVersion.lt(minEmberVersion)) {
-      return;
-    }
-
-    return this._super.config.apply(this, arguments);
-  },
-
   included() {
     this._super.included.apply(this, arguments);
+
+    const env = this.app.env;
+
+    // This configures EmberENV in a "hacky" way as the 'config' hook is called
+    // before the options from EmberApp are provided. There currently is no way of handling
+    // this case other than manually messing with configCache or modifing the dom by setting
+    // up window.EmberENV before ember loads.
+    Object.keys(flagToEnvironment).forEach(flag => {
+      this.project.config(env).EmberENV[flagToEnvironment[flag]] = this.flagValue(flag);
+    });
 
     // Always register the version
     this.import('vendor/ember-2-legacy/register-version.js');
 
     // do nothing if running with Ember 2.x
     if (this.emberVersion.lt(minEmberVersion)) {
+      debug(`Not including polyfills as we are running on ${this.emberVersion.version} and require a min of ${minEmberVersion}`);
       return;
     }
 
-    this.import('vendor/ember-k.js');
-    this.import('vendor/safe-string.js');
-    this.import('vendor/enumerable-contains.js');
-    this.import('vendor/underscore-actions.js');
-    this.import('vendor/reversed-observer.js');
-    this.import('vendor/initializer-arity.js');
-    this.import('vendor/router-resource.js');
-    this.import('vendor/link-to.js');
-    this.import('vendor/deprecated-registry.js');
-    this.import('vendor/immediate-observer.js');
-    this.import('vendor/string-fmt.js');
-    this.import('vendor/freezable.js');
-    this.import('vendor/component-defaultlayout.js');
-    this.import('vendor/binding.js');
-    this.import('vendor/text-support.js');
+    this.importUnlessFlagged('vendor/ember-k.js', ['ember-k']);
+    this.importUnlessFlagged('vendor/safe-string.js', ['safe-string']);
+    this.importUnlessFlagged('vendor/enumerable-contains.js', ['enumerable-contains']);
+    this.importUnlessFlagged('vendor/underscore-actions.js', ['underscore-actions']);
+    this.importUnlessFlagged('vendor/reversed-observer.js', ['reversed-observer']);
+    this.importUnlessFlagged('vendor/initializer-arity.js', ['initializer-arity']);
+    this.importUnlessFlagged('vendor/router-resource.js', ['router-resource']);
+    this.importUnlessFlagged('vendor/link-to.js', ['current-when', 'controller-wrapped']);
+    this.importUnlessFlagged('vendor/deprecated-registry.js', ['application-registry']);
+    this.importUnlessFlagged('vendor/immediate-observer.js', ['immediate-observer']);
+    this.importUnlessFlagged('vendor/string-fmt.js', ['string-fmt']);
+    this.importUnlessFlagged('vendor/freezable.js', ['ember-freezable']);
+    this.importUnlessFlagged('vendor/component-defaultlayout.js', ['component-defaultlayout']);
+    this.importUnlessFlagged('vendor/binding.js', ['ember-binding']);
+    this.importUnlessFlagged('vendor/text-support.js', ['input-transform']);
 
-    // Only include this in 3.0 as it has problems with 2.12 as
-    // as the AST has changed
-    const transform = require('./transforms/input');
-    this.app.registry.add('htmlbars-ast-plugin', {
-      name: 'transform-input-on-to-onEvent',
-      plugin: transform
-    });
+    if (this.flagValue('input-transform') !== false) {
+      const transform = require('./transforms/input');
+      this.app.registry.add('htmlbars-ast-plugin', {
+        name: 'transform-input-on-to-onEvent',
+        plugin: transform
+      });
+
+      debug('including the input transform');
+    }
   },
 
   treeForVendor(rawVendorTree) {
@@ -79,5 +109,19 @@ module.exports = {
     );
 
     return mergeTrees([registerVersionTree, transpiledVendorTree]);
+  },
+
+  flagValue(flag) {
+    let options = this.app.options[this.name] || {};
+    return options[flag] === false ? false : true;
+  },
+
+  importUnlessFlagged(path, flags) {
+    let shouldImport = flags.every(flag => this.flagValue(flag) !== false);
+
+    if (shouldImport) {
+      this.import(path);
+      debug(`including ${path}`);
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "broccoli-file-creator": "^1.1.1",
-    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-merge-trees": "~2.0.0",
     "debug": "^3.1.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-version-checker": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "broccoli-file-creator": "^1.1.1",
-    "broccoli-merge-trees": "~2.0.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "debug": "^3.1.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-version-checker": "^2.1.0"
   },


### PR DESCRIPTION
Allows individual deprecations to be turned on and off via:

```js
new EmberApp(defaults, {
  'ember-2-legacy': {
    'underscore-actions-support': false,
    // etc...
  }
});
```