### PR TITLE
Add Ember.required "polyfill"

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const VersionChecker = require('ember-cli-version-checker');
 const minEmberVersion = '3.0.0-beta.3';
 const flagToEnvironment = {
   'ember-k': '_ENABLE_EMBER_K_SUPPORT',
+  'ember-required': '_ENABLE_PROPERTY_REQUIRED_SUPPORT',
   'safe-string': '_ENABLE_SAFE_STRING_SUPPORT',
   'enumerable-contains': '_ENABLE_ENUMERABLE_CONTAINS_SUPPORT',
   'underscore-actions': '_ENABLE_UNDERSCORE_ACTIONS_SUPPORT',
@@ -67,6 +68,7 @@ module.exports = {
     }
 
     this.importUnlessFlagged('vendor/ember-k.js', ['ember-k']);
+    this.importUnlessFlagged('vendor/ember-required.js', ['ember-required']);
     this.importUnlessFlagged('vendor/safe-string.js', ['safe-string']);
     this.importUnlessFlagged('vendor/enumerable-contains.js', ['enumerable-contains']);
     this.importUnlessFlagged('vendor/underscore-actions.js', ['underscore-actions']);

--- a/tests/unit/ember-required.js
+++ b/tests/unit/ember-required.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import Object, { get } from '@ember/object';
+import { module, test } from 'qunit';
+
+module('Ember.required');
+
+test('that Ember.required is correctly polyfilled', function(assert) {
+  assert.equal(typeof Ember.required, 'function', 'function is defined on Ember');
+});
+
+test('that Ember.required properly returns this when invoked', function(assert) {
+  let Thing = Object.extend({ randomProp: Ember.required(), });
+
+  let instance = Thing.create();
+  assert.strictEqual(get(instance, 'randomProp'), instance, "Ember.required returns this");
+});
+
+test('that Ember.required is deprecated', function(assert) {
+  assert.expectDeprecation(() => {
+    let obj = { noop: Ember.required() };
+
+    assert.equal(undefined, get(obj, "noop"));
+  }, "Ember.required is deprecated as its behavior is inconsistent and unreliable.");
+});

--- a/vendor/ember-required.js
+++ b/vendor/ember-required.js
@@ -1,0 +1,30 @@
+(function() {
+  var _Ember;
+  if (typeof Ember !== 'undefined') {
+    _Ember = Ember;
+  } else {
+    _Ember = require('ember').default;
+  }
+
+  if (EmberENV && EmberENV._ENABLE_PROPERTY_REQUIRED_SUPPORT !== true) {
+    return false;
+  }
+
+  if (_Ember.hasOwnProperty('required')) {
+    return false;
+  }
+
+  Object.defineProperty(_Ember, 'required', {
+    get() {
+      _Ember.deprecate(
+        'Ember.required is deprecated as its behavior is inconsistent and unreliable.',
+        false,
+        { id: 'ember-metal.required', until: '3.0.0' }
+      );
+
+      // Returns an empty function because Ember.required was already unreliable and useless
+      // in practice.
+      return function() {};
+    }
+  });
+})();


### PR DESCRIPTION
The quotes in "polyfill" is because since the feature was already broken 
and useless in Ember 2.X, there was no point in trying to polyfill a
non-working feature, so this polyfill only adds an `Ember.required`
function that returns `undefined` but throws a deprecation.

The idea of a "placebo polyfill" comes from https://github.com/emberjs/ember.js/pull/16315#issuecomment-375852676