### PR TITLE
add new flag: 'ember-required' which implemented in #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In `ember-cli-build.js` you can specify a config for `ember-2-legacy`. This obje
 new EmberApp(defaults, {
   'ember-2-legacy': {
     'ember-k': false,
+    'ember-required': false,
     'safe-string': false,
     'enumerable-contains': false,
     'underscore-actions': false,


### PR DESCRIPTION
Added missed flag 'ember-required' into README which was implemented:
https://github.com/emberjs/ember-2-legacy/pull/66